### PR TITLE
Fix an issue with aws-cli installation on github actions.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
       # Install AWS CLI 2
       - name: Install AWS CLI 2
         run: |
+          sudo rm -rf /usr/local/aws
+          sudo rm /usr/local/bin/aws
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           sudo ./aws/install


### PR DESCRIPTION
If aws-cli is already installed (perhaps as a left over of half-done
deployment), you get an error message like:
````
Found preexisting AWS CLI installation: /usr/local/aws-cli/v2/current. Please rerun install script with --update flag
````
So, just nuke the folders where it's installed before doing a fresh install.